### PR TITLE
0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pricing4ts",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "![NPM Version](https://img.shields.io/npm/v/pricing4ts)\nPricing4TS is a TypeScript-based toolkit designed to enhance the server-side functionality of a pricing-driven SaaS by enabling the seamless integration of pricing plans into the application logic. The package provides a suite of components that are predicated on the Pricing2Yaml syntax, a specification that facilitates the definition of system's pricing and its features alongside their respective evaluation expressions, grouping them within plans and add-ons, as well as establishing usage limits.",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",


### PR DESCRIPTION
FEAT:

- New method in PricingService (`getConfigurationSpace`) to get the configuration space
- Added more concrete explanations for some minizinc errors
- More strict validations for the fields: integrationType and automationType of Pricing2Yaml

FIX:

- Calculation of the configuration space size: 	Due to the propagation of rounding errors in the cost calculation, MiniZinc would sometimes return duplicate configurations.