### PR TITLE
Fix: Avoid Exception When PAYMENT Features Are Disabled via Empty List

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pricing4ts",
-  "version": "0.9.6",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pricing4ts",
-      "version": "0.9.6",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@openfeature/server-sdk": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pricing4ts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "![NPM Version](https://img.shields.io/npm/v/pricing4ts)\nPricing4TS is a TypeScript-based toolkit designed to enhance the server-side functionality of a pricing-driven SaaS by enabling the seamless integration of pricing plans into the application logic. The package provides a suite of components that are predicated on the Pricing2Yaml syntax, a specification that facilitates the definition of system's pricing and its features alongside their respective evaluation expressions, grouping them within plans and add-ons, as well as establishing usage limits.",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",

--- a/src/main/utils/pricing-validators.ts
+++ b/src/main/utils/pricing-validators.ts
@@ -190,8 +190,8 @@ export function validateDefaultValue(
       break;
     case 'TEXT':
       if (elem.type === 'PAYMENT') {
-        if (!(elem.defaultValue instanceof Array) || elem.defaultValue.length === 0) {
-          throw new Error(`Payment method value must be an array of payment methods and not empty`);
+        if (!(elem.defaultValue instanceof Array)) {
+          throw new Error(`Payment method value must be an array of payment methods`);
         }
         for (const paymentMethod of elem.defaultValue) {
           if (
@@ -269,8 +269,8 @@ export function validateValue(
       break;
     case 'TEXT':
       if (elem.type === 'PAYMENT' && elem.value !== undefined) {
-        if (!(elem.value instanceof Array) || elem.value.length === 0) {
-          throw new Error(`Payment method value must be an array of payment methods and not empty`);
+        if (!(elem.value instanceof Array)) {
+          throw new Error(`Payment method value must be an array of payment methods`);
         }
         for (const paymentMethod of elem.value) {
           if (


### PR DESCRIPTION
Fix: Resolved a bug that caused an exception when a feature of type `PAYMENT` had an empty `defaultValue` or `value` (i.e., `[]`), which signifies the feature is disabled in the current configuration.

